### PR TITLE
add tags, categories and aliases to orgheaders

### DIFF
--- a/goorgeous.go
+++ b/goorgeous.go
@@ -358,7 +358,6 @@ func (p *parser) generateTable(output *bytes.Buffer, data []byte) {
 				table.WriteString("</tbody>\n")
 				tbodySet = false
 			}
-
 		}
 	}
 

--- a/header.go
+++ b/header.go
@@ -53,7 +53,7 @@ func OrgHeaders(input []byte) (map[string]interface{}, error) {
 		key := strings.Title(strings.ToLower(string(matches[1])))
 		val := matches[2]
 		switch {
-		case key == "Tags" || key == "Categories":
+		case key == "Tags" || key == "Categories" || key == "Aliases":
 			bTags := bytes.Split(val, []byte(" "))
 			tags := make([]string, len(bTags))
 			for idx, tag := range bTags {

--- a/header.go
+++ b/header.go
@@ -45,7 +45,25 @@ func OrgHeaders(input []byte) (map[string]interface{}, error) {
 			return out, nil
 		}
 		matches := reHeader.FindSubmatch(data)
-		out[strings.Title(strings.ToLower(string(matches[1])))] = string(matches[2])
+
+		if len(matches) < 3 {
+			continue
+		}
+
+		key := strings.Title(strings.ToLower(string(matches[1])))
+		val := matches[2]
+		switch {
+		case key == "Tags" || key == "Categories":
+			bTags := bytes.Split(val, []byte(" "))
+			tags := make([]string, len(bTags))
+			for idx, tag := range bTags {
+				tags[idx] = string(tag)
+			}
+			out[key] = tags
+		default:
+			out[key] = string(val)
+		}
+
 	}
 	return out, nil
 

--- a/header_test.go
+++ b/header_test.go
@@ -75,7 +75,7 @@ func TestOrgHeaders(t *testing.T) {
 				"Description": "This is my description!",
 				"Categories":  []string{"org-content", "org-mode", "hugo"},
 			}},
-		"basic-happy-path-with-aliases": {"#+TITLE: my org mode tags content\n#+author: Chase Adams\n#+DESCRIPTION: This is my description!\n#+CATEGORIES: /org/content /org/mode /hugo\n",
+		"basic-happy-path-with-aliases": {"#+TITLE: my org mode tags content\n#+author: Chase Adams\n#+DESCRIPTION: This is my description!\n#+ALIASES: /org/content /org/mode /hugo\n",
 			map[string]interface{}{
 				"Title":       "my org mode tags content",
 				"Author":      "Chase Adams",


### PR DESCRIPTION
add support for parsing tags, categories and aliases in `OrgHeaders`.