### PR TITLE
add better table support

### DIFF
--- a/goorgeous.go
+++ b/goorgeous.go
@@ -348,12 +348,14 @@ func (p *parser) generateTable(output *bytes.Buffer, data []byte) {
 				table.WriteString("<tbody>")
 				tbodySet = true
 			}
-			for _, cell := range bytes.Split(row[1:len(row)-1], []byte("|")) {
-				var cellBuff bytes.Buffer
-				p.inline(&cellBuff, bytes.Trim(cell, " \t"))
-				p.r.TableCell(&rowBuff, cellBuff.Bytes(), 0)
+			if !reTableHeaders.Match(row) {
+				for _, cell := range bytes.Split(row[1:len(row)-1], []byte("|")) {
+					var cellBuff bytes.Buffer
+					p.inline(&cellBuff, bytes.Trim(cell, " \t"))
+					p.r.TableCell(&rowBuff, cellBuff.Bytes(), 0)
+				}
+				p.r.TableRow(&table, rowBuff.Bytes())
 			}
-			p.r.TableRow(&table, rowBuff.Bytes())
 			if tbodySet && idx == len(rows)-1 {
 				table.WriteString("</tbody>\n")
 				tbodySet = false

--- a/goorgeous_test.go
+++ b/goorgeous_test.go
@@ -330,6 +330,25 @@ func TestRenderingBlock(t *testing.T) {
 	testOrgCommon(testCases, t)
 }
 
+func TestRenderingTables(t *testing.T) {
+	testCases := map[string]testCase{
+		"no-table-heading-no-horizontal-splits": {
+			"|foo|bar|baz|\n| d | e | f |\n| g | h | i |\n",
+			"\n<table>\n<tbody>\n<tr>\n<td>foo</td>\n<td>bar</td>\n<td>baz</td>\n</tr>\n\n<tr>\n<td>d</td>\n<td>e</td>\n<td>f</td>\n</tr>\n\n<tr>\n<td>g</td>\n<td>h</td>\n<td>i</td>\n</tr>\n</tbody>\n</table>\n",
+		},
+		"table-heading": {
+			"|foo|bar|baz|\n|---+---+---|\n| d | e | f |\n| g | h | i |\n",
+			"\n<table>\n<thead>\n<tr>\n<th>foo</th>\n<th>bar</th>\n<th>baz</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>d</td>\n<td>e</td>\n<td>f</td>\n</tr>\n\n<tr>\n<td>g</td>\n<td>h</td>\n<td>i</td>\n</tr>\n</tbody>\n</table>\n",
+		},
+		"no-table-heading-horizontal-splits": {
+			"|---+---+---|\n| d | e | f |\n|---+---+---|\n| g | h | i |\n|---+---+---|\n",
+			"\n<table>\n<tbody>\n<tr>\n<td>d</td>\n<td>e</td>\n<td>f</td>\n</tr>\n\n<tr>\n<td>g</td>\n<td>h</td>\n<td>i</td>\n</tr>\n</tbody>\n</table>\n",
+		},
+	}
+
+	testOrgCommon(testCases, t)
+}
+
 func TestRenderingPropertiesDrawer(t *testing.T) {
 	testCases := map[string]testCase{
 		"basic": {


### PR DESCRIPTION
fixes #8. Supports the following table variations:

basic:
```
| a | b | c |
| d | e | f |
| g | h | i |
```
basic with table headings:
```
| a | b | c |
|---+---+---|
| d | e | f |
| g | h | i |
```
with horizontal rules:
```
|---+---+---|
| a | b | c |
|---+---+---|
| d | e | f |
|---+---+---|
```
with horizontal rules and  table headings:
```
| a | b | c |
|---+---+---|
| d | e | f |
|---+---+---|
```
cc @kaushalmodi
