### PR TITLE
Support basic footnotes

### DIFF
--- a/goorgeous.go
+++ b/goorgeous.go
@@ -413,7 +413,6 @@ func isBlock(data []byte) bool {
 }
 
 // ~~ Footnotes
-var reFootnoteRef = regexp.MustCompile(`.+?\[fn:([\w]+)\]`)
 var reFootnoteDef = regexp.MustCompile(`^\[fn:([\w]+)\] +(.+)`)
 
 func isFootnoteDef(data []byte) bool {

--- a/goorgeous.go
+++ b/goorgeous.go
@@ -11,9 +11,15 @@ import (
 
 type inlineParser func(p *parser, out *bytes.Buffer, data []byte, offset int) int
 
+type footnotes struct {
+	id string
+	def string
+}
+
 type parser struct {
 	r              blackfriday.Renderer
 	inlineCallback [256]inlineParser
+	notes []footnotes
 }
 
 // NewParser returns a new parser with the inlineCallbacks required for org content
@@ -133,6 +139,13 @@ func OrgOptions(input []byte, renderer blackfriday.Renderer) []byte {
 				marker = string(matches[2])
 				syntax = string(matches[3])
 			}
+		case isFootnoteDef(data):
+			matches := reFootnoteDef.FindSubmatch(data)
+			for i := range p.notes {
+				if p.notes[i].id == string(matches[1]) {
+					p.notes[i].def = string(matches[2])
+				}
+			}
 		case isTable(data):
 			if inTable != true {
 				inTable = true
@@ -194,6 +207,16 @@ func OrgOptions(input []byte, renderer blackfriday.Renderer) []byte {
 		}
 	}
 
+	// Writing footnote def. list
+	if len(p.notes) > 0 {
+		flags := blackfriday.LIST_ITEM_BEGINNING_OF_LIST
+		p.r.Footnotes(&output, func() bool {
+			for i := range p.notes {
+				p.r.FootnoteItem(&output, []byte(p.notes[i].id), []byte(p.notes[i].def),flags)
+			}
+			return true
+		})
+	}
 	return output.Bytes()
 }
 
@@ -389,6 +412,14 @@ func isBlock(data []byte) bool {
 	return reBlock.Match(data)
 }
 
+// ~~ Footnotes
+var reFootnoteRef = regexp.MustCompile(`.+?\[fn:([\w]+)\]`)
+var reFootnoteDef = regexp.MustCompile(`^\[fn:([\w]+)\] +(.+)`)
+
+func isFootnoteDef(data []byte) bool {
+	return reFootnoteDef.Match(data)
+}
+
 // Elements
 // ~~ Keywords
 func IsKeyword(data []byte) bool {
@@ -571,7 +602,7 @@ func generateStrikethrough(p *parser, out *bytes.Buffer, data []byte, offset int
 	return generator(p, out, data, offset, '+', true, p.r.StrikeThrough)
 }
 
-// ~~ Images and Links
+// ~~ Images and Links (inc. Footnote)
 var reLinkOrImg = regexp.MustCompile(`\[\[(.+?)\]\[?(.*?)\]?\]`)
 
 func generateLinkOrImg(p *parser, out *bytes.Buffer, data []byte, offset int) int {
@@ -580,10 +611,13 @@ func generateLinkOrImg(p *parser, out *bytes.Buffer, data []byte, offset int) in
 	i := start
 	var hyperlink []byte
 	isImage := false
+	isFootnote := false
 	closedLink := false
 	hasContent := false
 
-	if data[0] != '[' {
+	if bytes.Equal(data[0:3],[]byte("fn:")) {
+		isFootnote = true;
+	} else if data[0] != '[' {
 		return 0
 	}
 
@@ -597,6 +631,15 @@ func generateLinkOrImg(p *parser, out *bytes.Buffer, data []byte, offset int) in
 		case charMatches(currChar, ']') && closedLink == false:
 			if isImage {
 				hyperlink = data[start+5 : i]
+			} else if isFootnote {
+				refid := data[start+2:i]
+				if bytes.Equal(refid,bytes.Trim(refid, " ")) {
+					p.notes = append(p.notes, footnotes{string(refid), "DEFINITION NOT FOUND"})
+					p.r.FootnoteRef(out,refid,len(p.notes))
+					return i + 2
+				} else {
+					return 0
+				}
 			} else if bytes.Equal(data[i-4:i], []byte(".org")) {
 				orgStart := start
 				if bytes.Equal(data[orgStart:orgStart+2], []byte("./")) {

--- a/goorgeous_test.go
+++ b/goorgeous_test.go
@@ -338,6 +338,24 @@ func TestRenderingLinksAndImages(t *testing.T) {
 	testOrgCommon(testCases, t)
 }
 
+func TestRenderingFootnotes(t *testing.T) {
+	testCases := testCase{"Test 1[fn:1] and Test 2[fn: 2] and Test 3[fn:3] also test lettres[fn:let] then final test[fn:4]\n\n[fn:let] what?\n\n\n[fn:6] And test it[fn:7].\n\n* Footnotes\n\n[fn:1] Test 1\n\n[fn:3] Test 3\n\n[fn:2] Test2\n\n[fn:5] missing?\n\n[fn:6] Six?\n\n[fn:7] Seven??",
+		"<p>Test 1<sup class=\"footnote-ref\" id=\"fnref:1\"><a rel=\"footnote\" href=\"#fn:1\">1</a></sup> and Test 2[fn: 2] and Test 3<sup class=\"footnote-ref\" id=\"fnref:3\"><a rel=\"footnote\" href=\"#fn:3\">2</a></sup> also test lettres<sup class=\"footnote-ref\" id=\"fnref:let\"><a rel=\"footnote\" href=\"#fn:let\">3</a></sup> then final test<sup class=\"footnote-ref\" id=\"fnref:4\"><a rel=\"footnote\" href=\"#fn:4\">4</a></sup></p>\n\n<h1 id=\"footnotes\">Footnotes</h1>\n<div class=\"footnotes\">\n\n<hr />\n\n<ol>\n<li id=\"fn:1\">Test 1 <a class=\"footnote-return\" href=\"#fnref:1\"><sup>↩</sup></a></li>\n\n<li id=\"fn:3\">Test 3 <a class=\"footnote-return\" href=\"#fnref:3\"><sup>↩</sup></a></li>\n\n<li id=\"fn:let\">what? <a class=\"footnote-return\" href=\"#fnref:let\"><sup>↩</sup></a></li>\n\n<li id=\"fn:4\">DEFINITION NOT FOUND <a class=\"footnote-return\" href=\"#fnref:4\"><sup>↩</sup></a></li>\n</ol>\n</div>"}
+
+	flags := blackfriday.HTML_USE_XHTML;
+	flags |= blackfriday.LIST_ITEM_BEGINNING_OF_LIST
+	flags |= blackfriday.HTML_FOOTNOTE_RETURN_LINKS
+
+	var parameters blackfriday.HtmlRendererParameters
+	parameters.FootnoteReturnLinkContents = "<sup>↩</sup>"
+	
+	renderer := blackfriday.HtmlRendererWithParameters(flags, "", "", parameters)
+	out := Org([]byte(testCases.in),renderer)
+	if !bytes.Equal(out,[]byte(testCases.expected)) {
+		t.Errorf("Footnote for Org() from: \n %s \n result: \n  %s\n wants:\n  %s",testCases.in, string(out), testCases.expected)
+	}
+}	
+
 func TestRenderingBlock(t *testing.T) {
 
 	testCases := map[string]testCase{

--- a/goorgeous_test.go
+++ b/goorgeous_test.go
@@ -340,7 +340,7 @@ func TestRenderingLinksAndImages(t *testing.T) {
 
 func TestRenderingFootnotes(t *testing.T) {
 	testCases := testCase{"Test 1[fn:1] and Test 2[fn: 2] and Test 3[fn:3] also test lettres[fn:let] then final test[fn:4]\n\n[fn:let] what?\n\n\n[fn:6] And test it[fn:7].\n\n* Footnotes\n\n[fn:1] Test 1\n\n[fn:3] Test 3\n\n[fn:2] Test2\n\n[fn:5] missing?\n\n[fn:6] Six?\n\n[fn:7] Seven??",
-		"<p>Test 1<sup class=\"footnote-ref\" id=\"fnref:1\"><a rel=\"footnote\" href=\"#fn:1\">1</a></sup> and Test 2[fn: 2] and Test 3<sup class=\"footnote-ref\" id=\"fnref:3\"><a rel=\"footnote\" href=\"#fn:3\">2</a></sup> also test lettres<sup class=\"footnote-ref\" id=\"fnref:let\"><a rel=\"footnote\" href=\"#fn:let\">3</a></sup> then final test<sup class=\"footnote-ref\" id=\"fnref:4\"><a rel=\"footnote\" href=\"#fn:4\">4</a></sup></p>\n\n<h1 id=\"footnotes\">Footnotes</h1>\n<div class=\"footnotes\">\n\n<hr />\n\n<ol>\n<li id=\"fn:1\">Test 1 <a class=\"footnote-return\" href=\"#fnref:1\"><sup>↩</sup></a></li>\n\n<li id=\"fn:3\">Test 3 <a class=\"footnote-return\" href=\"#fnref:3\"><sup>↩</sup></a></li>\n\n<li id=\"fn:let\">what? <a class=\"footnote-return\" href=\"#fnref:let\"><sup>↩</sup></a></li>\n\n<li id=\"fn:4\">DEFINITION NOT FOUND <a class=\"footnote-return\" href=\"#fnref:4\"><sup>↩</sup></a></li>\n</ol>\n</div>"}
+		"<p>Test 1<sup class=\"footnote-ref\" id=\"fnref:1\"><a rel=\"footnote\" href=\"#fn:1\">1</a></sup> and Test 2[fn: 2] and Test 3<sup class=\"footnote-ref\" id=\"fnref:3\"><a rel=\"footnote\" href=\"#fn:3\">2</a></sup> also test lettres<sup class=\"footnote-ref\" id=\"fnref:let\"><a rel=\"footnote\" href=\"#fn:let\">3</a></sup> then final test<sup class=\"footnote-ref\" id=\"fnref:4\"><a rel=\"footnote\" href=\"#fn:4\">4</a></sup></p>\n\n<h1 id=\"footnotes\">Footnotes</h1>\n<div class=\"footnotes\">\n\n<hr />\n\n<ol>\n<li id=\"fn:1\">Test 1 <a class=\"footnote-return\" href=\"#fnref:1\"><sup>↩</sup></a></li>\n\n<li id=\"fn:3\">Test 3 <a class=\"footnote-return\" href=\"#fnref:3\"><sup>↩</sup></a></li>\n\n<li id=\"fn:let\">what? <a class=\"footnote-return\" href=\"#fnref:let\"><sup>↩</sup></a></li>\n\n<li id=\"fn:4\">DEFINITION NOT FOUND <a class=\"footnote-return\" href=\"#fnref:4\"><sup>↩</sup></a></li>\n</ol>\n</div>\n"}
 
 	flags := blackfriday.HTML_USE_XHTML;
 	flags |= blackfriday.LIST_ITEM_BEGINNING_OF_LIST
@@ -351,6 +351,7 @@ func TestRenderingFootnotes(t *testing.T) {
 	
 	renderer := blackfriday.HtmlRendererWithParameters(flags, "", "", parameters)
 	out := Org([]byte(testCases.in),renderer)
+
 	if !bytes.Equal(out,[]byte(testCases.expected)) {
 		t.Errorf("Footnote for Org() from: \n %s \n result: \n  %s\n wants:\n  %s",testCases.in, string(out), testCases.expected)
 	}


### PR DESCRIPTION
add support for basic `[fn:name]` style footnotes, described in [here](http://orgmode.org/manual/Footnotes.html).