### PR TITLE
Fixes panic when tmpBlock has no length.

### DIFF
--- a/goorgeous.go
+++ b/goorgeous.go
@@ -57,6 +57,7 @@ func OrgOptions(input []byte, renderer blackfriday.Renderer) []byte {
 	marker := ""
 	syntax := ""
 	listType := ""
+	inParagraph := false
 	inList := false
 	inTable := false
 	var tmpBlock bytes.Buffer
@@ -75,7 +76,10 @@ func OrgOptions(input []byte, renderer blackfriday.Renderer) []byte {
 			case inTable:
 				p.generateTable(&output, tmpBlock.Bytes())
 				inTable = false
-				listType = ""
+				tmpBlock.Reset()
+			case inParagraph:
+				p.generateParagraph(&output, tmpBlock.Bytes()[:len(tmpBlock.Bytes())-1])
+				inParagraph = false
 				tmpBlock.Reset()
 			case marker != "":
 				tmpBlock.WriteByte('\n')
@@ -190,8 +194,16 @@ func OrgOptions(input []byte, renderer blackfriday.Renderer) []byte {
 		case isHorizontalRule(data):
 			p.r.HRule(&output)
 		default:
-			p.generateParagraph(&output, data)
+			if inParagraph == false {
+				inParagraph = true
+			}
+			tmpBlock.Write(data)
+			tmpBlock.WriteByte('\n')
 		}
+	}
+
+	if len(tmpBlock.Bytes()) > 0 {
+		p.generateParagraph(&output, tmpBlock.Bytes()[:len(tmpBlock.Bytes())-1])
 	}
 
 	return output.Bytes()

--- a/goorgeous.go
+++ b/goorgeous.go
@@ -65,6 +65,24 @@ func OrgOptions(input []byte, renderer blackfriday.Renderer) []byte {
 	for scanner.Scan() {
 		data := scanner.Bytes()
 
+		if !isEmpty(data) && isComment(data) || IsKeyword(data) {
+			switch {
+			case inList:
+				p.generateList(&output, tmpBlock.Bytes(), listType)
+				inList = false
+				listType = ""
+				tmpBlock.Reset()
+			case inTable:
+				p.generateTable(&output, tmpBlock.Bytes())
+				inTable = false
+				tmpBlock.Reset()
+			case inParagraph:
+				p.generateParagraph(&output, tmpBlock.Bytes()[:len(tmpBlock.Bytes())-1])
+				inParagraph = false
+				tmpBlock.Reset()
+			}
+		}
+
 		switch {
 		case isEmpty(data):
 			switch {

--- a/goorgeous.go
+++ b/goorgeous.go
@@ -87,16 +87,22 @@ func OrgOptions(input []byte, renderer blackfriday.Renderer) []byte {
 		case isEmpty(data):
 			switch {
 			case inList:
-				p.generateList(&output, tmpBlock.Bytes(), listType)
+				if tmpBlock.Len() > 0 {
+					p.generateList(&output, tmpBlock.Bytes(), listType)
+				}
 				inList = false
 				listType = ""
 				tmpBlock.Reset()
 			case inTable:
-				p.generateTable(&output, tmpBlock.Bytes())
+				if tmpBlock.Len() > 0 {
+					p.generateTable(&output, tmpBlock.Bytes())
+				}
 				inTable = false
 				tmpBlock.Reset()
 			case inParagraph:
-				p.generateParagraph(&output, tmpBlock.Bytes()[:len(tmpBlock.Bytes())-1])
+				if tmpBlock.Len() > 0 {
+					p.generateParagraph(&output, tmpBlock.Bytes()[:len(tmpBlock.Bytes())-1])
+				}
 				inParagraph = false
 				tmpBlock.Reset()
 			case marker != "":

--- a/goorgeous_test.go
+++ b/goorgeous_test.go
@@ -465,6 +465,16 @@ func TestRenderingPropertiesDrawer(t *testing.T) {
 	testOrgCommon(testCases, t)
 }
 
+func TestRenderingComplexTexts(t *testing.T) {
+	testCases := map[string]testCase{
+		"newline": {
+			"** Start a new paragraph\nAn empty line starts a new paragraph.\n#+BEGIN_SRC text\n/Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo\nligula nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque\neu, sem. Nulla consequat massa quis enim./\n\n/In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam\ndictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus\nelementum semper nisi./\n#+END_SRC\n/Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, sem. Nulla consequat massa quis enim./\n\n/In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi./\n",
+			"<h2 id=\"start-a-new-paragraph\">Start a new paragraph</h2>\n\n<p>An empty line starts a new paragraph.</p>\n\n<pre><code class=\"language-text\">\n/Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo\nligula nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque\neu, sem. Nulla consequat massa quis enim./\n\n/In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam\ndictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus\nelementum semper nisi./\n</code></pre>\n\n<p><em>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, sem. Nulla consequat massa quis enim.</em></p>\n\n<p><em>In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi.</em></p>\n",
+		},
+	}
+	testOrgCommon(testCases, t)
+}
+
 func testOrgCommon(testCases map[string]testCase, t *testing.T) {
 	for caseName, tc := range testCases {
 

--- a/goorgeous_test.go
+++ b/goorgeous_test.go
@@ -226,6 +226,12 @@ func TestRenderingInline(t *testing.T) {
 		"no-inline": {"this string should have no inline changes.\n",
 			"<p>this string should have no inline changes.</p>\n",
 		},
+		"newline": {"this string should have\nan inline change.\n",
+			"<p>this string should have\nan inline change.</p>\n",
+		},
+		"double-newline": {"this string should have\nan inline change.\n\nAnd a new paragraph.\n",
+			"<p>this string should have\nan inline change.</p>\n\n<p>And a new paragraph.</p>\n",
+		},
 		"emphasis": {
 			"this string /has emphasis text/.\n",
 			"<p>this string <em>has emphasis text</em>.</p>\n",
@@ -330,7 +336,7 @@ func TestRenderingLinksAndImages(t *testing.T) {
 			"<p>this has <img src=\"https://github.com/chaseadamsio/goorgeous/img.png\" alt=\"https://github.com/chaseadamsio/goorgeous/img.png\" title=\"https://github.com/chaseadamsio/goorgeous/img.png\" /> as an image.</p>\n",
 		},
 		"image-alt": {
-			"this has [[file:../gopher.gif][a uni-gopher]] as an image.",
+			"this has [[file:../gopher.gif][a uni-gopher]] as an image.\n",
 			"<p>this has <img src=\"../gopher.gif\" alt=\"a uni-gopher\" title=\"a uni-gopher\" /> as an image.</p>\n",
 		},
 	}


### PR DESCRIPTION
Fixes #37. The temporary block where the html was being stored before being written to the output had a zero length and was causing an out of bound slice call. @Unknwon 