### PR TITLE
Handle tables with a single row.

### DIFF
--- a/goorgeous.go
+++ b/goorgeous.go
@@ -403,7 +403,10 @@ func isTable(data []byte) bool {
 func (p *parser) generateTable(output *bytes.Buffer, data []byte) {
 	var table bytes.Buffer
 	rows := bytes.Split(bytes.Trim(data, "\n"), []byte("\n"))
-	hasTableHeaders := reTableHeaders.Match(rows[1])
+	hasTableHeaders := len(rows) > 1
+	if len(rows) > 1 {
+		hasTableHeaders = reTableHeaders.Match(rows[1])
+	}
 	tbodySet := false
 
 	for idx, row := range rows {

--- a/goorgeous_test.go
+++ b/goorgeous_test.go
@@ -348,20 +348,20 @@ func TestRenderingFootnotes(t *testing.T) {
 	testCases := testCase{"Test 1[fn:1] and Test 2[fn: 2] and Test 3[fn:3] also test lettres[fn:let] then final test[fn:4]\n\n[fn:let] what?\n\n\n[fn:6] And test it[fn:7].\n\n* Footnotes\n\n[fn:1] Test 1\n\n[fn:3] Test 3\n\n[fn:2] Test2\n\n[fn:5] missing?\n\n[fn:6] Six?\n\n[fn:7] Seven??",
 		"<p>Test 1<sup class=\"footnote-ref\" id=\"fnref:1\"><a rel=\"footnote\" href=\"#fn:1\">1</a></sup> and Test 2[fn: 2] and Test 3<sup class=\"footnote-ref\" id=\"fnref:3\"><a rel=\"footnote\" href=\"#fn:3\">2</a></sup> also test lettres<sup class=\"footnote-ref\" id=\"fnref:let\"><a rel=\"footnote\" href=\"#fn:let\">3</a></sup> then final test<sup class=\"footnote-ref\" id=\"fnref:4\"><a rel=\"footnote\" href=\"#fn:4\">4</a></sup></p>\n\n<h1 id=\"footnotes\">Footnotes</h1>\n<div class=\"footnotes\">\n\n<hr />\n\n<ol>\n<li id=\"fn:1\">Test 1 <a class=\"footnote-return\" href=\"#fnref:1\"><sup>↩</sup></a></li>\n\n<li id=\"fn:3\">Test 3 <a class=\"footnote-return\" href=\"#fnref:3\"><sup>↩</sup></a></li>\n\n<li id=\"fn:let\">what? <a class=\"footnote-return\" href=\"#fnref:let\"><sup>↩</sup></a></li>\n\n<li id=\"fn:4\">DEFINITION NOT FOUND <a class=\"footnote-return\" href=\"#fnref:4\"><sup>↩</sup></a></li>\n</ol>\n</div>\n"}
 
-	flags := blackfriday.HTML_USE_XHTML;
+	flags := blackfriday.HTML_USE_XHTML
 	flags |= blackfriday.LIST_ITEM_BEGINNING_OF_LIST
 	flags |= blackfriday.HTML_FOOTNOTE_RETURN_LINKS
 
 	var parameters blackfriday.HtmlRendererParameters
 	parameters.FootnoteReturnLinkContents = "<sup>↩</sup>"
-	
-	renderer := blackfriday.HtmlRendererWithParameters(flags, "", "", parameters)
-	out := Org([]byte(testCases.in),renderer)
 
-	if !bytes.Equal(out,[]byte(testCases.expected)) {
-		t.Errorf("Footnote for Org() from: \n %s \n result: \n  %s\n wants:\n  %s",testCases.in, string(out), testCases.expected)
+	renderer := blackfriday.HtmlRendererWithParameters(flags, "", "", parameters)
+	out := Org([]byte(testCases.in), renderer)
+
+	if !bytes.Equal(out, []byte(testCases.expected)) {
+		t.Errorf("Footnote for Org() from: \n %s \n result: \n  %s\n wants:\n  %s", testCases.in, string(out), testCases.expected)
 	}
-}	
+}
 
 func TestRenderingBlock(t *testing.T) {
 
@@ -440,6 +440,10 @@ func TestRenderingTables(t *testing.T) {
 		"table-with-inlined-elements": {
 			"| Format           | Org mode markup syntax |\n| *Bold*           | =*Bold*=               |\n| /Italics/        | =/Italics/=            |\n| _Underline_      | =_Underline_=          |\n| =Verbatim=       | ==Verbatim== |\n| +Strike-through+ | =+Strike-through+=     |\n",
 			"\n<table>\n<tbody>\n<tr>\n<td>Format</td>\n<td>Org mode markup syntax</td>\n</tr>\n\n<tr>\n<td><strong>Bold</strong></td>\n<td><code>*Bold*</code></td>\n</tr>\n\n<tr>\n<td><em>Italics</em></td>\n<td><code>/Italics/</code></td>\n</tr>\n\n<tr>\n<td><span style=\"text-decoration: underline;\">Underline</span></td>\n<td><code>_Underline_</code></td>\n</tr>\n\n<tr>\n<td><code>Verbatim</code></td>\n<td><code>=Verbatim=</code></td>\n</tr>\n\n<tr>\n<td><del>Strike-through</del></td>\n<td><code>+Strike-through+</code></td>\n</tr>\n</tbody>\n</table>\n",
+		},
+		"table-single-cell": {
+			"| r |\n",
+			"\n<table>\n<tbody>\n<tr>\n<td>r</td>\n</tr>\n</tbody>\n</table>\n",
 		},
 	}
 


### PR DESCRIPTION
This fixes #42 

The issue is that `hasTableHeaders := reTableHeaders.Match(rows[1])` is called when there is no guarantee that there is more than one row. Thus the array is indexed out of bounds and the program panics.