### PR TITLE
Code beginning with a dot is not rendered as code

### DIFF
--- a/goorgeous.go
+++ b/goorgeous.go
@@ -622,7 +622,8 @@ func isTerminatingChar(char byte) bool {
 func findLastCharInInline(data []byte, char byte) int {
 	timesFound := 0
 	last := 0
-	for i := 0; i < len(data); i++ {
+	// Start from character after the inline indicator
+	for i := 1; i < len(data); i++ {
 		if timesFound == 1 {
 			break
 		}

--- a/goorgeous_test.go
+++ b/goorgeous_test.go
@@ -236,7 +236,7 @@ func TestRenderingInline(t *testing.T) {
 			"this string /has emphasis text/.\n",
 			"<p>this string <em>has emphasis text</em>.</p>\n",
 		},
-		"emphasis-with-dot": {
+		"emphasis-with-dot-at-front": {
 			"this string /.has emphasis text/.\n",
 			"<p>this string <em>.has emphasis text</em>.</p>\n",
 		},
@@ -284,7 +284,7 @@ func TestRenderingInline(t *testing.T) {
 			"this string *has bold text*.\n",
 			"<p>this string <strong>has bold text</strong>.</p>\n",
 		},
-		"bold-with-dot": {
+		"bold-with-dot-at-front": {
 			"this string *.has bold text*.\n",
 			"<p>this string <strong>.has bold text</strong>.</p>\n",
 		},
@@ -312,7 +312,7 @@ func TestRenderingInline(t *testing.T) {
 			"this is _underlined text_.\n",
 			"<p>this is <span style=\"text-decoration: underline;\">underlined text</span>.</p>\n",
 		},
-		"underline-with-dot": {
+		"underline-with-dot-at-front": {
 			"this is _.underlined text_.\n",
 			"<p>this is <span style=\"text-decoration: underline;\">.underlined text</span>.</p>\n",
 		},

--- a/goorgeous_test.go
+++ b/goorgeous_test.go
@@ -236,6 +236,10 @@ func TestRenderingInline(t *testing.T) {
 			"this string /has emphasis text/.\n",
 			"<p>this string <em>has emphasis text</em>.</p>\n",
 		},
+		"emphasis-with-dot": {
+			"this string /.has emphasis text/.\n",
+			"<p>this string <em>.has emphasis text</em>.</p>\n",
+		},
 		"emphasis-with-slash-inside": {
 			"this string /has a slash/inside and emphasis text/.\n",
 			"<p>this string <em>has a slash/inside and emphasis text</em>.</p>\n",
@@ -280,6 +284,10 @@ func TestRenderingInline(t *testing.T) {
 			"this string *has bold text*.\n",
 			"<p>this string <strong>has bold text</strong>.</p>\n",
 		},
+		"bold-with-dot": {
+			"this string *.has bold text*.\n",
+			"<p>this string <strong>.has bold text</strong>.</p>\n",
+		},
 		"bold-with-asterisk-inside": {
 			"this string *has *asterisk and bold text*.\n",
 			"<p>this string <strong>has *asterisk and bold text</strong>.</p>\n",
@@ -304,9 +312,17 @@ func TestRenderingInline(t *testing.T) {
 			"this is _underlined text_.\n",
 			"<p>this is <span style=\"text-decoration: underline;\">underlined text</span>.</p>\n",
 		},
+		"underline-with-dot": {
+			"this is _.underlined text_.\n",
+			"<p>this is <span style=\"text-decoration: underline;\">.underlined text</span>.</p>\n",
+		},
 		"verbatim": {
 			"this is =inline code=.\n",
 			"<p>this is <code>inline code</code>.</p>\n",
+		},
+		"verbatim-with-dot-at-front": {
+			"this is =.inline code=.\n",
+			"<p>this is <code>.inline code</code>.</p>\n",
 		},
 		"verbatim-with-equal-in-code": {
 			"this is =inline=code=.\n",
@@ -331,6 +347,10 @@ func TestRenderingInline(t *testing.T) {
 		"code": {
 			"this has ~code~.\n",
 			"<p>this has <code>code</code>.</p>\n",
+		},
+		"code-with-dot-at-front": {
+			"this has ~.code~.\n",
+			"<p>this has <code>.code</code>.</p>\n",
 		},
 		"code-not": {
 			"this has not~code~.\n",


### PR DESCRIPTION
This is fix for #54 

Since dot is considered as terminating character finding the dot after the
beginning of the inline indicator terminates the inline. So starting from the
character after the beginning of inline indicator.
