### PR TITLE
Checking the length of the field before trying to access the content

### DIFF
--- a/goorgeous.go
+++ b/goorgeous.go
@@ -525,7 +525,7 @@ func IsKeyword(data []byte) bool {
 
 // ~~ Comments
 func isComment(data []byte) bool {
-	return charMatches(data[0], '#') && charMatches(data[1], ' ')
+	return len(data) > 1 && charMatches(data[0], '#') && charMatches(data[1], ' ')
 }
 
 func (p *parser) generateComment(out *bytes.Buffer, data []byte) {


### PR DESCRIPTION
Checking the length of the field before trying to access the content as this is causing a crash when the first character is # without any subsequent characters. 
Fix for #53 